### PR TITLE
Fix bronze color definition in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,8 @@ module.exports = withMT({
   theme: {
     extend: {
       colors: {
-        'bronze': '##ca8a04'
+        // Custom color used for Bronze sponsors
+        'bronze': '#ca8a04'
       }
     },
   },


### PR DESCRIPTION
## Summary
- fix typo in `tailwind.config.js` defining bronze color

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840329425b4832dbf3c9c0aa5dcd52b